### PR TITLE
Fix typing

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -14,8 +14,9 @@ FutureClass.ClassName = "Future"
 
 export type Future<T...> = typeof(setmetatable(
 	{} :: {
+		status: "pending" | "completed",
 		awaiting: { [thread]: boolean },
-		getValue: (() -> T...)?,
+		getValue: () -> T...,
 	},
 	FutureClass
 ))
@@ -33,8 +34,9 @@ export type Future<T...> = typeof(setmetatable(
 function FutureStatic.new<T...>()
 	local self = setmetatable({}, FutureClass) :: Future<T...>
 
+	self.status = "pending"
 	self.awaiting = {}
-	self.getValue = nil
+	self.getValue = function() end
 
 	return self
 end
@@ -83,9 +85,8 @@ function FutureStatic.race<T...>(futures: { Future<T...> })
 	local future = FutureStatic.new() :: Future<T...>
 
 	for _, racingFuture in futures do
-		local castedFuture = racingFuture :: Future<...any>
-		if castedFuture:isCompleted() then
-			future:complete(castedFuture:expect())
+		if racingFuture.status == "completed" then
+			future:complete(racingFuture.getValue())
 		end
 	end
 
@@ -120,7 +121,7 @@ end
 	@return boolean
 ]=]
 function FutureClass.isCompleted<T...>(self: Future<T...>)
-	return not not self.getValue
+	return self.status == "completed"
 end
 
 --[=[
@@ -135,12 +136,14 @@ end
 	@param ... T... -- The completed values.
 ]=]
 function FutureClass.complete<T...>(self: Future<T...>, ...: T...)
-	assert(self.getValue == nil, "Cannot complete a future that is already completed")
+	assert(self.status ~= "completed", "Cannot complete a future that is already completed")
 
 	local packed = table.pack(...)
 	self.getValue = function()
 		return table.unpack(packed :: { any }, 1, packed.n)
 	end
+
+	self.status = "completed"
 
 	local awaiting = self.awaiting
 	self.awaiting = {}
@@ -159,7 +162,7 @@ end
 	@return T... -- The completed values.
 ]=]
 function FutureClass.expect<T...>(self: Future<T...>): T...
-	if self.getValue then
+	if self.status == "completed" then
 		return self.getValue()
 	end
 

--- a/src/init.spec.luau
+++ b/src/init.spec.luau
@@ -2,6 +2,20 @@
 
 local DELAY_TIME = 0.1
 
+type Packed<T> = { [number]: T, n: number }
+
+local function isArrEqual(arr1: Packed<any>, arr2: Packed<any>)
+	if arr1.n ~= arr2.n then
+		return false
+	end
+	for i = 1, arr1.n do
+		if arr1[i] ~= arr2[i] then
+			return false
+		end
+	end
+	return true
+end
+
 return function()
 	local Future = require(script.Parent)
 
@@ -37,9 +51,9 @@ return function()
 			expect(f:isCompleted()).to.equal(false)
 			f:complete("Hello", "world!", 123, true, arr)
 			expect(f:isCompleted()).to.equal(true)
-			expect(f:expect()).to.equal("Hello", "world!", 123, true, arr)
+			expect(isArrEqual(table.pack(f:expect()), table.pack("Hello", "world!", 123, true, arr))).to.equal(true)
 			expect(f:isCompleted()).to.equal(true)
-			expect(f:expect()).to.equal("Hello", "world!", 123, true, arr)
+			expect(isArrEqual(table.pack(f:expect()), table.pack("Hello", "world!", 123, true, arr))).to.equal(true)
 		end)
 
 		it("should complete / expect with multiple values with a delay.", function()
@@ -51,9 +65,9 @@ return function()
 			end)
 
 			expect(f:isCompleted()).to.equal(false)
-			expect(f:expect()).to.equal("Hello", "world!", 123, true, arr)
+			expect(isArrEqual(table.pack(f:expect()), table.pack("Hello", "world!", 123, true, arr))).to.equal(true)
 			expect(f:isCompleted()).to.equal(true)
-			expect(f:expect()).to.equal("Hello", "world!", 123, true, arr)
+			expect(isArrEqual(table.pack(f:expect()), table.pack("Hello", "world!", 123, true, arr))).to.equal(true)
 		end)
 	end)
 
@@ -69,7 +83,7 @@ return function()
 			local f = Future.completed("Hello", "world!", 123, true, arr)
 
 			expect(f:isCompleted()).to.equal(true)
-			expect(f:expect()).to.equal("Hello", "world!", 123, true, arr)
+			expect(isArrEqual(table.pack(f:expect()), table.pack("Hello", "world!", 123, true, arr))).to.equal(true)
 		end)
 	end)
 
@@ -86,7 +100,7 @@ return function()
 			local f = Future.delay(DELAY_TIME, "Hello", "world!", 123, true, arr)
 
 			expect(f:isCompleted()).to.equal(false)
-			expect(f:expect()).to.equal("Hello", "world!", 123, true, arr)
+			expect(isArrEqual(table.pack(f:expect()), table.pack("Hello", "world!", 123, true, arr))).to.equal(true)
 			expect(f:isCompleted()).to.equal(true)
 		end)
 	end)
@@ -137,7 +151,7 @@ return function()
 			expect(race:isCompleted()).to.equal(false)
 			f2:complete(2, false, "world!")
 			expect(race:isCompleted()).to.equal(true)
-			expect(race:expect()).to.equal(2, false, "world!")
+			expect(isArrEqual(table.pack(race:expect()), table.pack(2, false, "world!"))).to.equal(true)
 		end)
 
 		it("should be race with multiple values with delay.", function()
@@ -154,7 +168,7 @@ return function()
 			end)
 
 			expect(race:isCompleted()).to.equal(false)
-			expect(race:expect()).to.equal(1, true, "Hello")
+			expect(isArrEqual(table.pack(race:expect()), table.pack(1, true, "Hello"))).to.equal(true)
 			expect(race:isCompleted()).to.equal(true)
 		end)
 	end)


### PR DESCRIPTION
This PR adjusts the typing of the future class such that the type checker stores a reference to the generic type pack. This is important since it provides the ability to get types from the `:expect()` methods.

```luau
local f = Future.completed(1, "Hello world!", true)

-- before
local a, b, c = f:expect() -- any, any, any

-- after
local a, b, c = f:expect() -- number, string, boolean
```