### PR TITLE
Add Future.all constructor

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -108,6 +108,29 @@ function FutureStatic.race<T...>(futures: { Future<T...> })
 	return future
 end
 
+--[=[
+	@within Future
+	@tag Constructors
+
+	Creates a new future that completes when all the provided futures have completed.
+
+	@param futures { Future<T...> }
+	@return Future<()>
+]=]
+function FutureStatic.all<T...>(futures: { Future<T...> })
+	local allFuture = FutureStatic.new() :: Future<()>
+
+	task.spawn(function()
+		for _, future in futures do
+			local castedFuture = future :: Future<...any>
+			castedFuture:expect()
+		end
+		allFuture:complete()
+	end)
+
+	return allFuture
+end
+
 -- Public Methods
 
 --[=[

--- a/src/init.luau
+++ b/src/init.luau
@@ -27,7 +27,7 @@ export type Future<T...> = typeof(setmetatable(
 	@within Future
 	@tag Constructors
 
-	Creates an uncompleted future.
+	Creates a pending future.
 
 	@return Future<T...>
 ]=]
@@ -115,19 +115,39 @@ end
 
 	Creates a new future that completes when all the provided futures have completed.
 
+	The completed value is an array containing the input futures in the order they completed.
+
+	```lua
+	local f1 = Future.delay(1, "foo")
+	local f2 = Future.completed("bar")
+	Future.all({ f1, f2 }):expect() -- { f2, f1 }
+	```
+
 	@param futures { Future<T...> }
-	@return Future<()>
+	@return Future<{ Future<T...> }>
 ]=]
 function FutureStatic.all<T...>(futures: { Future<T...> })
-	local allFuture = FutureStatic.new() :: Future<()>
+	local allFuture = FutureStatic.new() :: Future<{ Future<T...> }>
 
-	task.spawn(function()
-		for _, future in futures do
-			local castedFuture = future :: Future<...any>
-			castedFuture:expect()
+	local resolved = {}
+	local function markCompleted(future: Future<T...>)
+		table.insert(resolved, future)
+		if #resolved == #futures then
+			allFuture:complete(resolved)
 		end
-		allFuture:complete()
-	end)
+	end
+
+	for _, future in futures do
+		local castedFuture = future :: Future<...any>
+		if castedFuture.status == "completed" then
+			markCompleted(castedFuture)
+		else
+			task.spawn(function()
+				castedFuture:expect()
+				markCompleted(castedFuture)
+			end)
+		end
+	end
 
 	return allFuture
 end

--- a/src/init.spec.luau
+++ b/src/init.spec.luau
@@ -172,4 +172,46 @@ return function()
 			expect(race:isCompleted()).to.equal(true)
 		end)
 	end)
+
+	describe(".all()", function()
+		it("should resolve with single values.", function()
+			local f1 = Future.delay(DELAY_TIME, "Hello")
+			local f2 = Future.completed("world!")
+			local all = Future.all({ f1, f2 })
+
+			expect(all:isCompleted()).to.equal(false)
+
+			local ordered = all:expect()
+			expect(ordered[1]).to.equal(f2)
+			expect(ordered[2]).to.equal(f1)
+
+			expect(all:isCompleted()).to.equal(true)
+		end)
+
+		it("should resolve with multiple values.", function()
+			local f1 = Future.delay(DELAY_TIME, 1, "Hello", true)
+			local f2 = Future.completed(2, "world!", false)
+			local all = Future.all({ f1, f2 })
+
+			expect(all:isCompleted()).to.equal(false)
+
+			local ordered = all:expect()
+			expect(ordered[1]).to.equal(f2)
+			expect(ordered[2]).to.equal(f1)
+
+			expect(all:isCompleted()).to.equal(true)
+		end)
+
+		it("should resolve with instant values.", function()
+			local f1 = Future.completed(1)
+			local f2 = Future.completed(2)
+			local all = Future.all({ f1, f2 })
+
+			expect(all:isCompleted()).to.equal(true)
+
+			local ordered = all:expect()
+			expect(ordered[1]).to.equal(f1)
+			expect(ordered[2]).to.equal(f2)
+		end)
+	end)
 end


### PR DESCRIPTION
This PR adds the `Future.all` constructor. This is useful for when you have multiple futures and you want to ensure that all of them have completed.

The completed value is an array containing the input futures in the order they completed.

```luau
local f1 = Future.delay(1, "foo")
local f2 = Future.completed("bar")
Future.all({ f1, f2 }):expect() -- { f2, f1 }
```