### PR TITLE
Add `Future.fromSignal`

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -82,6 +82,12 @@ type Signal<T...> = {
 
 	Creates a new future that completes when the provided signal fires and when the predicate (if provided) passes.
 
+	```lua
+	Future.fromSignal(game:GetService("Players").PlayerAdded, function(player)
+		return player.UserId == 1 -- only complete when player w/ UserId == 1 joins the game!
+	end)
+	```
+
 	@param signal Signal<T...> -- Something with similar connect method structure to RbxScriptSignal<T...>
 	@param predicate ((T...) -> boolean)?
 	@return Future<T...>

--- a/src/init.luau
+++ b/src/init.luau
@@ -72,7 +72,21 @@ function FutureStatic.delay<T...>(sec: number, ...: T...)
 	return future
 end
 
-function FutureStatic.fromEvent<T...>(signal: RBXScriptSignal<T...>, predicate: ((T...) -> boolean)?)
+type Signal<T...> = {
+	Connect: (Signal<T...>, (T...) -> ()) -> any | { Disconnect: (any) -> () }, -- Unable to get typechecker to work with disconnect atm...
+}
+
+--[=[
+	@within Future
+	@tag Constructors
+
+	Creates a new future that completes when the provided signal fires and when the predicate (if provided) passes.
+
+	@param signal Signal<T...> -- Something with similar connect method structure to RbxScriptSignal<T...>
+	@param predicate ((T...) -> boolean)?
+	@return Future<T...>
+]=]
+function FutureStatic.fromSignal<S, T...>(signal: Signal<T...>, predicate: ((T...) -> boolean)?)
 	local future = FutureStatic.new() :: Future<T...>
 
 	local connection
@@ -84,7 +98,10 @@ function FutureStatic.fromEvent<T...>(signal: RBXScriptSignal<T...>, predicate: 
 				return
 			end
 		end
-		connection:Disconnect()
+
+		if connection.Disconnect then
+			connection:Disconnect()
+		end
 	end)
 
 	return future

--- a/src/init.luau
+++ b/src/init.luau
@@ -70,6 +70,24 @@ function FutureStatic.delay<T...>(sec: number, ...: T...)
 	return future
 end
 
+function FutureStatic.fromEvent<T...>(signal: RBXScriptSignal<T...>, predicate: ((T...) -> boolean)?)
+	local future = FutureStatic.new() :: Future<T...>
+
+	local connection
+	connection = signal:Connect(function(...)
+		if not future:isCompleted() then
+			if not predicate or predicate(...) then
+				future:complete(...)
+			else
+				return
+			end
+		end
+		connection:Disconnect()
+	end)
+
+	return future
+end
+
 --[=[
 	@within Future
 	@tag Constructors

--- a/src/init.spec.luau
+++ b/src/init.spec.luau
@@ -214,4 +214,47 @@ return function()
 			expect(ordered[2]).to.equal(f2)
 		end)
 	end)
+
+	describe(".fromSignal()", function()
+		FOCUS()
+
+		local Signal = require(game.ReplicatedStorage.DevPackages.Signal)
+		local RunService = game:GetService("RunService") :: RunService
+
+		it("should work without a predicate", function()
+			local f = Future.fromSignal(RunService.Heartbeat)
+
+			expect(f:expect() > 0).to.equal(true)
+			expect(f:isCompleted()).to.equal(true)
+		end)
+
+		it("should work with a predicate", function()
+			local s = Signal.new() :: Signal.Signal<any>
+			local f = Future.fromSignal(s, function(x)
+				return x == "foo"
+			end)
+
+			s:Fire(1)
+			s:Fire(false)
+			s:Fire("foo")
+
+			expect(f:isCompleted()).to.equal(true)
+			expect(f:expect()).to.equal("foo")
+		end)
+
+		it("should work with a predicate and post fires", function()
+			local s = Signal.new() :: Signal.Signal<any>
+			local f = Future.fromSignal(s, function(x)
+				return x == "foo"
+			end)
+
+			s:Fire(1)
+			s:Fire(false)
+			s:Fire("foo")
+			s:Fire({})
+
+			expect(f:isCompleted()).to.equal(true)
+			expect(f:expect()).to.equal("foo")
+		end)
+	end)
 end

--- a/wally.lock
+++ b/wally.lock
@@ -5,9 +5,14 @@ registry = "test"
 [[package]]
 name = "egomoose/future"
 version = "0.1.0"
-dependencies = [["TestEZ", "roblox/testez@0.4.1"]]
+dependencies = [["Signal", "sleitnick/signal@2.0.3"], ["TestEZ", "roblox/testez@0.4.1"]]
 
 [[package]]
 name = "roblox/testez"
 version = "0.4.1"
+dependencies = []
+
+[[package]]
+name = "sleitnick/signal"
+version = "2.0.3"
 dependencies = []

--- a/wally.toml
+++ b/wally.toml
@@ -11,3 +11,4 @@ include = ["src", "src/**", "wally.toml", "wally.lock", "default.project.json", 
 
 [dev-dependencies]
 TestEZ = "roblox/testez@0.4.1"
+Signal = "sleitnick/signal@2.0.3"


### PR DESCRIPTION
This PR adds a new constructor `Future.fromSignal`. This allows for quickly creating futures that complete when a signal is fired.

Additionally, it's possible to pass an optional predicate provided with the fired signal values that must return true for the future to complete.