### PR TITLE
Add `Future.packAsCallback`

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -193,6 +193,29 @@ function FutureStatic.all<T...>(futures: { Future<T...> })
 	return allFuture
 end
 
+-- Static Methods
+
+--[=[
+	@within Future
+	@tag Static Methods
+
+	Packs a list of values into a callback that returns the values when called.
+
+	```lua
+	local unpackCallback = Future.packAsCallback(1, "foo", true)
+	local a, b, c = unpackCallback() -- number, string, boolean
+	```
+
+	@param ... T... -- The completed values.
+	@return () -> (T...)
+]=]
+function FutureStatic.packAsCallback<T...>(...: T...)
+	local future = FutureStatic.completed(...)
+	return function()
+		return future:expect()
+	end
+end
+
 -- Public Methods
 
 --[=[

--- a/src/init.spec.luau
+++ b/src/init.spec.luau
@@ -255,4 +255,24 @@ return function()
 			expect(f:expect()).to.equal("foo")
 		end)
 	end)
+
+	describe(".packAsCallback()", function()
+		it("should pack single values", function()
+			local unpackCallback = Future.packAsCallback(1)
+
+			expect(typeof(unpackCallback)).to.equal("function")
+			expect(unpackCallback()).to.equal(1)
+		end)
+
+		it("should pack multiple values", function()
+			local unpackCallback = Future.packAsCallback(1, "foo", true)
+
+			expect(typeof(unpackCallback)).to.equal("function")
+
+			local a, b, c = unpackCallback()
+			expect(a).to.equal(1)
+			expect(b).to.equal("foo")
+			expect(c).to.equal(true)
+		end)
+	end)
 end


### PR DESCRIPTION
This PR adds a new static method that packs a list of values into a callback that returns the values when called.

```luau
local unpackCallback = Future.packAsCallback(1, "foo", true)
local a, b, c = unpackCallback() -- number, string, boolean
```

This can be helpful for cases where the typing of a generic typepack is needs to be stored as something other than varargs.