### PR TITLE
Unify packAsCallback

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -303,4 +303,4 @@ end
 
 --
 
-return FutureStatic
+return table.clone(FutureStatic)

--- a/src/init.luau
+++ b/src/init.luau
@@ -16,7 +16,7 @@ export type Future<T...> = typeof(setmetatable(
 	{} :: {
 		status: "pending" | "completed",
 		awaiting: { [thread]: boolean },
-		getValue: () -> T...,
+		getValues: () -> T...,
 	},
 	FutureClass
 ))
@@ -36,7 +36,7 @@ function FutureStatic.new<T...>()
 
 	self.status = "pending"
 	self.awaiting = {}
-	self.getValue = function() end
+	self.getValues = function() end
 
 	return self
 end
@@ -154,7 +154,7 @@ function FutureStatic.race<T...>(futures: { Future<T...> })
 
 	for _, racingFuture in futures do
 		if racingFuture.status == "completed" then
-			future:complete(racingFuture.getValue())
+			future:complete(racingFuture.getValues())
 		end
 	end
 
@@ -237,9 +237,9 @@ end
 	@return () -> (T...)
 ]=]
 function FutureStatic.packAsCallback<T...>(...: T...)
-	local future = FutureStatic.completed(...)
-	return function()
-		return future:expect()
+	local packed = table.pack(...)
+	return function(): T...
+		return table.unpack(packed :: { any }, 1, packed.n)
 	end
 end
 
@@ -272,11 +272,7 @@ end
 function FutureClass.complete<T...>(self: Future<T...>, ...: T...)
 	assert(self.status ~= "completed", "Cannot complete a future that is already completed")
 
-	local packed = table.pack(...)
-	self.getValue = function()
-		return table.unpack(packed :: { any }, 1, packed.n)
-	end
-
+	self.getValues = FutureStatic.packAsCallback(...)
 	self.status = "completed"
 
 	local awaiting = self.awaiting
@@ -297,7 +293,7 @@ end
 ]=]
 function FutureClass.expect<T...>(self: Future<T...>): T...
 	if self.status == "completed" then
-		return self.getValue()
+		return self.getValues()
 	end
 
 	local thread = coroutine.running()


### PR DESCRIPTION
This PR changes how packAsCallback works so that it doesn't rely on futures to work. This was done for two reasons:
1. It reduces overhead and makes the call simpler.
2. The function is now used in the internals of futures reducing duplicate code.

Additionally, we now `table.clone` the module result so that devs don't break the code if they overwrite any fields in the return. Potentially `table.freeze` would've worked as well, but this is a bit more flexible.