### PR TITLE
Rename `Future.async` to `Future.spawn`

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -60,21 +60,21 @@ end
 	@within Future
 	@tag Constructors
 
-	Creates a future that completes with the return values from the provided async function.
+	Creates a future that completes with the return values from the provided function.
 
 	```lua
 	local function getNameFromUserIdAsync(userId: number)
 		return game.Players:GetNameFromUserIdAsync(userId)
 	end
 
-	local f = Future.async(getNameFromUserIdAsync, 1)
+	local f = Future.spawn(getNameFromUserIdAsync, 1)
 	print(f:expect()) -- Roblox
 	```
 
 	@param callback (A...) -> (T...)
 	@return Future<T...>
 ]=]
-function FutureStatic.async<A..., T...>(callback: (A...) -> T..., ...: A...)
+function FutureStatic.spawn<A..., T...>(callback: (A...) -> T..., ...: A...)
 	local future = FutureStatic.new() :: Future<T...>
 	local packedArgs = table.pack(...)
 	task.spawn(function()
@@ -303,4 +303,4 @@ end
 
 --
 
-return table.clone(FutureStatic)
+return table.clone(FutureStatic) :: typeof(FutureStatic)

--- a/src/init.spec.luau
+++ b/src/init.spec.luau
@@ -87,9 +87,9 @@ return function()
 		end)
 	end)
 
-	describe(".async()", function()
+	describe(".spawn()", function()
 		it("should be completed with single values.", function()
-			local f = Future.async(function()
+			local f = Future.spawn(function()
 				return "Hello world!"
 			end)
 			expect(f:isCompleted()).to.equal(true)
@@ -98,7 +98,7 @@ return function()
 
 		it("should be completed with multiple values.", function()
 			local arr = { 1, 2, 3 }
-			local f = Future.async(function()
+			local f = Future.spawn(function()
 				return "Hello", "world!", 123, true, arr
 			end)
 
@@ -108,7 +108,7 @@ return function()
 
 		it("should be work with yielding functions.", function()
 			local arr = { 1, 2, 3 }
-			local f = Future.async(function()
+			local f = Future.spawn(function()
 				task.wait(1)
 				return "Hello", "world!", 123, true, arr
 			end)


### PR DESCRIPTION
This PR renames `Future.async` to `Future.spawn` which is a more clear name. This is a backwards compatible breaking change.